### PR TITLE
output addresses for troubleshooting

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ Give (internal) custom domains to services, rather than using the hostnames/IPs 
 1. Visit the setup page.
 
     ```sh
-    open http://$(terraform output public_ip)/blog/wp-admin/install.php
+    open $(terraform output url)wp-admin/install.php
     ```
 
 ## Deployment

--- a/README.md
+++ b/README.md
@@ -110,3 +110,11 @@ For initial or subsequent deployment:
     ```sh
     terraform apply
     ```
+
+## Troubleshooting
+
+To SSH into the running instance:
+
+```sh
+ssh $(terraform output ssh_user)@$(terraform output public_ip)
+```

--- a/terraform/outputs.tf
+++ b/terraform/outputs.tf
@@ -1,3 +1,7 @@
+output "ssh_user" {
+  value = "${var.ssh_user}"
+}
+
 output "public_ip" {
   value = "${aws_instance.wordpress.public_ip}"
 }

--- a/terraform/outputs.tf
+++ b/terraform/outputs.tf
@@ -21,3 +21,7 @@ output "db_user" {
 output "db_pass" {
   value = "${aws_db_instance.wordpress.password}"
 }
+
+output "url" {
+  value = "http://${aws_instance.wordpress.public_ip}/blog/"
+}

--- a/terraform/vars.tf
+++ b/terraform/vars.tf
@@ -22,3 +22,7 @@ variable "db_pass" {
   description = "The database password"
   type = "string"
 }
+
+variable "ssh_user" {
+  default = "ubuntu"
+}


### PR DESCRIPTION
Add the URL to the outputs for visiting the site easily, and include a single command for connecting to the instance via SSH.