### PR TITLE
switch to using new Terraform VPC module

### DIFF
--- a/terraform/aws.tf
+++ b/terraform/aws.tf
@@ -9,3 +9,7 @@ terraform {
     key = "terraform/terraform.tfstate"
   }
 }
+
+data "aws_region" "current" {
+  current = true
+}

--- a/terraform/aws.tf
+++ b/terraform/aws.tf
@@ -1,5 +1,6 @@
 provider "aws" {
-  version = "~> 0.1"
+  // https://github.com/terraform-providers/terraform-provider-aws/issues/1625
+  version = "~> 1.0"
 }
 
 terraform {

--- a/terraform/dns.tf
+++ b/terraform/dns.tf
@@ -1,10 +1,11 @@
-data "aws_route53_zone" "private" {
-  name = "${module.network.private_mgmt_dns_zone_name}"
-  private_zone = true
+resource "aws_route53_zone" "private" {
+  name = "${var.private_zone_name}"
+  // this argument makes it a Private Hosted Zone
+  vpc_id = "${module.network.vpc_id}"
 }
 
 resource "aws_route53_record" "db" {
-  zone_id = "${data.aws_route53_zone.private.zone_id}"
+  zone_id = "${aws_route53_zone.private.zone_id}"
   name = "db"
   type = "CNAME"
   ttl = "30"

--- a/terraform/ec2.tf
+++ b/terraform/ec2.tf
@@ -15,7 +15,7 @@ data "aws_ami" "wordpress" {
 }
 
 data "aws_subnet" "public" {
-  id = "${module.network.mgmt_public_subnet_ids[0]}"
+  id = "${module.network.public_subnets[0]}"
 }
 
 resource "aws_instance" "wordpress" {

--- a/terraform/network.tf
+++ b/terraform/network.tf
@@ -1,16 +1,25 @@
 module "network" {
-  source = "git::https://github.com/GSA/DevSecOps.git?ref=21dcc28//terraform"
+  source = "terraform-aws-modules/vpc/aws"
 
-  aws_az1 = "${data.aws_region.current.name}d"
-  aws_az2 = "${data.aws_region.current.name}f"
+  azs = [
+    "${data.aws_region.current.name}d",
+    "${data.aws_region.current.name}f"
+  ]
 
-  mgmt_vpc_name = "devsecops-example"
-  private_mgmt_zone_name = "${var.private_zone_name}"
+  name = "devsecops-example"
 
-  devsecops_flow_log_policy = "devsecops_example_flow_log"
-  mgmt_dns_hostnames = "true"
-  mgmt_dns_support = "true"
-  mgmt_nat_gateway = "true"
-  mgmt_flow_log_group_name = "devsecops_example_flow_log"
-  devsecops_iam_log_role_name = "devsecops_example_flow_log"
+  enable_dns_hostnames = true
+  enable_dns_support = true
+  database_subnets = ["${var.database_subnet_cidrs}"]
+  public_subnets = ["${var.public_subnet_cidr}"]
+  enable_nat_gateway = true
+  cidr = "${var.vpc_cidr}"
+}
+
+module "flow_logs" {
+  source = "git::https://github.com/GSA/DevSecOps.git?ref=fb535d3//terraform/modules/vpc_flow_log"
+
+  vpc_id = "${module.network.vpc_id}"
+  // not actually the name, but required by this module
+  vpc_name = "devsecops-example"
 }

--- a/terraform/network.tf
+++ b/terraform/network.tf
@@ -8,13 +8,9 @@ module "network" {
   private_mgmt_zone_name = "${var.private_zone_name}"
 
   devsecops_flow_log_policy = "devsecops_example_flow_log"
-  mgmt_private_subnet_cidrs = ["${var.vpc_cidr}"]
   mgmt_dns_hostnames = "true"
   mgmt_dns_support = "true"
-  mgmt_database_subnet_cidrs = ["${var.database_subnet_cidrs}"]
-  mgmt_public_subnet_cidrs = ["${var.public_subnet_cidr}"]
   mgmt_nat_gateway = "true"
   mgmt_flow_log_group_name = "devsecops_example_flow_log"
   devsecops_iam_log_role_name = "devsecops_example_flow_log"
-  mgmt_vpc_cidr = "${var.vpc_cidr}"
 }

--- a/terraform/network.tf
+++ b/terraform/network.tf
@@ -17,9 +17,6 @@ module "network" {
 }
 
 module "flow_logs" {
-  source = "git::https://github.com/GSA/DevSecOps.git?ref=fb535d3//terraform/modules/vpc_flow_log"
-
+  source = "github.com/GSA/terraform-vpc-flow-log"
   vpc_id = "${module.network.vpc_id}"
-  // not actually the name, but required by this module
-  vpc_name = "devsecops-example"
 }

--- a/terraform/outputs.tf
+++ b/terraform/outputs.tf
@@ -7,7 +7,7 @@ output "public_ip" {
 }
 
 output "public_subnet_id" {
-  value = "${module.network.mgmt_public_subnet_ids[0]}"
+  value = "${module.network.public_subnets[0]}"
 }
 
 output "db_host" {

--- a/terraform/rds.tf
+++ b/terraform/rds.tf
@@ -12,7 +12,7 @@ resource "aws_db_instance" "wordpress" {
   username = "wordpressuser"
   password = "${var.db_pass}"
 
-  db_subnet_group_name = "${module.network.mgmt_database_subnet_group_name}"
+  db_subnet_group_name = "${module.network.database_subnet_group}"
   vpc_security_group_ids = ["${aws_security_group.wordpress_db.id}"]
 
   lifecycle {

--- a/terraform/rds.tf
+++ b/terraform/rds.tf
@@ -12,7 +12,7 @@ resource "aws_db_instance" "wordpress" {
   username = "wordpressuser"
   password = "${var.db_pass}"
 
-  db_subnet_group_name = "${module.network.mgmt_database_subnet_ids[0]}"
+  db_subnet_group_name = "${module.network.mgmt_database_subnet_group_name}"
   vpc_security_group_ids = ["${aws_security_group.wordpress_db.id}"]
 
   lifecycle {

--- a/terraform/security.tf
+++ b/terraform/security.tf
@@ -1,7 +1,7 @@
 resource "aws_security_group" "wordpress_ec2" {
   name = "wordpress"
   description = "rules for production traffic"
-  vpc_id = "${module.network.mgmt_vpc_id}"
+  vpc_id = "${module.network.vpc_id}"
   tags {
     Name = "WordPress EC2 rules"
   }
@@ -44,7 +44,7 @@ resource "aws_security_group" "wordpress_ec2" {
 resource "aws_security_group" "wordpress_db" {
   name        = "WordPress (DB)"
   description = "RDS security group for WordPress."
-  vpc_id      = "${module.network.mgmt_vpc_id}"
+  vpc_id      = "${module.network.vpc_id}"
   tags {
     Name = "WordPress RDS rules"
   }
@@ -53,13 +53,13 @@ resource "aws_security_group" "wordpress_db" {
     from_port   = 3306
     to_port     = 3306
     protocol    = "tcp"
-    cidr_blocks = ["${module.network.mgmt_vpc_cidr_block}"]
+    cidr_blocks = ["${var.vpc_cidr}"]
   }
 
   egress {
     from_port   = 3306
     to_port     = 3306
     protocol    = "tcp"
-    cidr_blocks = ["${module.network.mgmt_vpc_cidr_block}"]
+    cidr_blocks = ["${var.vpc_cidr}"]
   }
 }

--- a/terraform/security.tf
+++ b/terraform/security.tf
@@ -53,13 +53,13 @@ resource "aws_security_group" "wordpress_db" {
     from_port   = 3306
     to_port     = 3306
     protocol    = "tcp"
-    cidr_blocks = ["${var.vpc_cidr}"]
+    cidr_blocks = ["${module.network.mgmt_vpc_cidr_block}"]
   }
 
   egress {
     from_port   = 3306
     to_port     = 3306
     protocol    = "tcp"
-    cidr_blocks = ["${var.vpc_cidr}"]
+    cidr_blocks = ["${module.network.mgmt_vpc_cidr_block}"]
   }
 }

--- a/terraform/vars.tf
+++ b/terraform/vars.tf
@@ -1,3 +1,15 @@
+variable "vpc_cidr" {
+  default = "10.0.0.0/16"
+}
+
+variable "public_subnet_cidr" {
+  default = "10.0.0.0/24"
+}
+
+variable "database_subnet_cidrs" {
+  default = ["10.0.101.0/24", "10.0.102.0/24"]
+}
+
 variable "ip_whitelist" {
   default = "0.0.0.0/0"
 }

--- a/terraform/vars.tf
+++ b/terraform/vars.tf
@@ -1,15 +1,3 @@
-variable "vpc_cidr" {
-  default = "10.0.0.0/16"
-}
-
-variable "public_subnet_cidr" {
-  default = "10.0.0.0/24"
-}
-
-variable "database_subnet_cidrs" {
-  default = ["10.0.101.0/24", "10.0.102.0/24"]
-}
-
 variable "ip_whitelist" {
   default = "0.0.0.0/0"
 }

--- a/terraform/vpc.tf
+++ b/terraform/vpc.tf
@@ -1,3 +1,0 @@
-data "aws_region" "current" {
-  current = true
-}


### PR DESCRIPTION
Builds on #34.

Doesn't seem like we have a need to maintain our own VPC module (at the moment) so switching to use the new off-the-shelf one. Since [that module doesn't include flow logs](https://github.com/terraform-community-modules/tf_aws_vpc/issues/64), split out [a separate module for them](https://github.com/GSA/terraform-vpc-flow-log), and am using that here as well.