### PR TITLE
fix CIDR usage

### DIFF
--- a/terraform/network.tf
+++ b/terraform/network.tf
@@ -8,13 +8,9 @@ module "network" {
   private_mgmt_zone_name = "${var.private_zone_name}"
 
   devsecops_flow_log_policy = "devsecops_example_flow_log"
-  mgmt_private_subnet_cidrs = ["${var.vpc_cidr}"]
   mgmt_dns_hostnames = "true"
   mgmt_dns_support = "true"
-  mgmt_database_subnet_cidrs = ["${var.database_subnet_cidrs}"]
-  mgmt_public_subnet_cidrs = ["${var.public_subnet_cidr}"]
   mgmt_nat_gateway = "true"
   mgmt_flow_log_group_name = "devsecops_example_flow_log"
   devsecops_iam_log_role_name = "devsecops_example_flow_log"
-  mgmt_vpc_cidr = "${var.vpc_cidr}"
 }

--- a/terraform/rds.tf
+++ b/terraform/rds.tf
@@ -12,7 +12,7 @@ resource "aws_db_instance" "wordpress" {
   username = "wordpressuser"
   password = "${var.db_pass}"
 
-  db_subnet_group_name = "${module.network.mgmt_database_subnet_ids[0]}"
+  db_subnet_group_name = "${module.network.mgmt_database_subnet_group_name}"
   vpc_security_group_ids = ["${aws_security_group.wordpress_db.id}"]
 
   lifecycle {

--- a/terraform/security.tf
+++ b/terraform/security.tf
@@ -53,13 +53,13 @@ resource "aws_security_group" "wordpress_db" {
     from_port   = 3306
     to_port     = 3306
     protocol    = "tcp"
-    cidr_blocks = ["${var.vpc_cidr}"]
+    cidr_blocks = ["${module.network.mgmt_vpc_cidr_block}"]
   }
 
   egress {
     from_port   = 3306
     to_port     = 3306
     protocol    = "tcp"
-    cidr_blocks = ["${var.vpc_cidr}"]
+    cidr_blocks = ["${module.network.mgmt_vpc_cidr_block}"]
   }
 }

--- a/terraform/vars.tf
+++ b/terraform/vars.tf
@@ -1,15 +1,3 @@
-variable "vpc_cidr" {
-  default = "10.0.0.0/16"
-}
-
-variable "public_subnet_cidr" {
-  default = "10.0.0.0/24"
-}
-
-variable "database_subnet_cidrs" {
-  default = ["10.0.101.0/24", "10.0.102.0/24"]
-}
-
 variable "ip_whitelist" {
   default = "0.0.0.0/0"
 }


### PR DESCRIPTION
Conflicting CIDRs were being used - this now just uses the defaults, which is easier. Fixes the `terraform apply`.