### PR TITLE
remove unnecessary AWS configuration for Packer

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,6 @@ WordPress runs on an Ubuntu 16.04 EC2 instance in a public subnet, and connects 
     ```sh
     packer build \
       -var jenkins_host=$(terraform output jenkins_host) \
-      -var subnet_id=$(terraform output public_subnet_id) \
       ../../packer/jenkins.json
 
     terraform apply
@@ -117,7 +116,6 @@ For initial or subsequent deployment:
 
     ```sh
     packer build \
-      -var subnet_id=$(terraform output public_subnet_id) \
       -var db_host=$(terraform output db_host) \
       -var db_name=$(terraform output db_name) \
       -var db_user=$(terraform output db_user) \

--- a/packer/jenkins.json
+++ b/packer/jenkins.json
@@ -1,10 +1,7 @@
 {
   "variables": {
-    "aws_access_key": "",
-    "aws_secret_key": "",
     "jenkins_host": null,
-    "region": "{{env `AWS_DEFAULT_REGION`}}",
-    "subnet_id": null
+    "region": "{{env `AWS_DEFAULT_REGION`}}"
   },
   "provisioners": [
     {
@@ -16,8 +13,6 @@
   ],
   "builders": [{
     "type": "amazon-ebs",
-    "access_key": "{{user `aws_access_key`}}",
-    "secret_key": "{{user `aws_secret_key`}}",
     "region": "{{user `region`}}",
     "source_ami_filter": {
       "filters": {
@@ -29,7 +24,6 @@
       "most_recent": true
     },
     "instance_type": "t2.micro",
-    "subnet_id": "{{user `subnet_id`}}",
     "ssh_username": "ec2-user",
     "ami_name": "jenkins {{timestamp}}"
   }]

--- a/packer/wordpress.json
+++ b/packer/wordpress.json
@@ -1,13 +1,10 @@
 {
   "variables": {
-    "aws_access_key": "",
-    "aws_secret_key": "",
     "db_host": null,
     "db_name": null,
     "db_user": null,
     "db_pass": null,
-    "region": "{{env `AWS_DEFAULT_REGION`}}",
-    "subnet_id": null
+    "region": "{{env `AWS_DEFAULT_REGION`}}"
   },
   "provisioners": [
     {
@@ -18,8 +15,6 @@
   ],
   "builders": [{
     "type": "amazon-ebs",
-    "access_key": "{{user `aws_access_key`}}",
-    "secret_key": "{{user `aws_secret_key`}}",
     "region": "{{user `region`}}",
     "source_ami_filter": {
       "filters": {
@@ -31,7 +26,6 @@
       "most_recent": true
     },
     "instance_type": "t2.micro",
-    "subnet_id": "{{user `subnet_id`}}",
     "ssh_username": "ubuntu",
     "ami_name": "wordpress {{timestamp}}"
   }]

--- a/terraform/env/outputs.tf
+++ b/terraform/env/outputs.tf
@@ -6,10 +6,6 @@ output "public_ip" {
   value = "${aws_eip.public.public_ip}"
 }
 
-output "public_subnet_id" {
-  value = "${module.network.public_subnets[0]}"
-}
-
 output "db_host" {
   value = "${aws_route53_record.db.fqdn}"
 }

--- a/terraform/mgmt/outputs.tf
+++ b/terraform/mgmt/outputs.tf
@@ -1,7 +1,3 @@
-output "public_subnet_id" {
-  value = "${module.network.public_subnets[0]}"
-}
-
 output "jenkins_host" {
   value = "${aws_eip.jenkins.public_ip}"
 }


### PR DESCRIPTION
Split out of #41.

The AWS credentials can be read automatically through environment variables, so there isn't a need to include them in the arguments explicitly.

https://www.packer.io/docs/builders/amazon.html#automatic-lookup

Also removed the subnet_ids being passed from Terraform to Packer, since Packer doesn't need to use a VPC/subnet.