### PR TITLE
switch to using a and b availability zones

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -34,7 +34,7 @@ jobs:
     docker:
       - image: hashicorp/terraform
         environment:
-          AWS_DEFAULT_REGION: us-east-1
+          AWS_DEFAULT_REGION: us-east-2
     steps:
       - checkout
       - attach_workspace:

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ WordPress runs on an Ubuntu 16.04 EC2 instance in a public subnet, and connects 
 
     ```sh
     cd ../mgmt
-    export AWS_DEFAULT_REGION=us-east-1
+    export AWS_DEFAULT_REGION=us-east-2
     terraform init
     terraform apply
     ```
@@ -92,7 +92,7 @@ WordPress runs on an Ubuntu 16.04 EC2 instance in a public subnet, and connects 
 1. Set up environment using Terraform.
 
     ```sh
-    export AWS_DEFAULT_REGION=us-east-1
+    export AWS_DEFAULT_REGION=us-east-2
     terraform init
     ```
 

--- a/terraform/env/network.tf
+++ b/terraform/env/network.tf
@@ -1,10 +1,9 @@
 module "network" {
   source = "terraform-aws-modules/vpc/aws"
 
-  # these are somewhat arbitrary - they were faster to provision resources in than `us-east-1a` and `us-east-1b`
   azs = [
-    "${data.aws_region.current.name}d",
-    "${data.aws_region.current.name}f"
+    "${data.aws_region.current.name}a",
+    "${data.aws_region.current.name}b"
   ]
 
   name = "devsecops-example"


### PR DESCRIPTION
Split out of #41.

Have been testing with `us-east-2` region, which only goes `a`-`c`.