### PR TITLE
make the instance type of the Jenkins server configurable

### DIFF
--- a/terraform/mgmt/jenkins.tf
+++ b/terraform/mgmt/jenkins.tf
@@ -28,6 +28,7 @@ module "jenkins_instances" {
   source = "../../ansible/roles/gsa.jenkins/terraform/modules/instances"
 
   ami = "${data.aws_ami.jenkins.id}"
+  instance_type = "${var.jenkins_instance_type}"
   key_name = "${aws_key_pair.deployer.key_name}"
   subnet_id = "${module.network.public_subnets[0]}"
   vm_user = "${local.jenkins_ssh_user}"

--- a/terraform/mgmt/variables.tf
+++ b/terraform/mgmt/variables.tf
@@ -5,3 +5,7 @@ variable "vpc_cidr" {
 variable "public_subnet_cidr" {
   default = "10.0.0.0/24"
 }
+
+variable "jenkins_instance_type" {
+  default = "t2.micro"
+}


### PR DESCRIPTION
t2.micro is really just for demonstration purposes - it can't handle any non-trivial builds. This gives the ability to override it.