### PR TITLE
don't check if WordPress is reachable when building the AMI

### DIFF
--- a/ansible/wordpress.yml
+++ b/ansible/wordpress.yml
@@ -61,9 +61,3 @@
       systemd:
         name: apache2
         state: restarted
-
-    - name: Ensure WordPress is reachable
-      uri:
-        url: http://127.0.0.1/blog/
-        # if WordPress hasn't been "installed", it will redirect to the install wizard
-        status_codes: 200,302


### PR DESCRIPTION
As of #43, the AMI isn't going to be built in a place where it can access the database, so WordPress is going to give errors when it's visited in the context of a Packer build. This task should be moved to a smoke test.