### PR TITLE
work around cyclical dependency when setting up mgmt

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -34,6 +34,7 @@ jobs:
     docker:
       - image: hashicorp/terraform
         environment:
+          # arbitrary region
           AWS_DEFAULT_REGION: us-east-2
     steps:
       - checkout

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -12,6 +12,7 @@ pipeline {
         docker { image 'hashicorp/terraform' }
       }
       environment {
+        // TODO make configurable
         AWS_DEFAULT_REGION = 'us-east-2'
       }
       steps {

--- a/README.md
+++ b/README.md
@@ -35,10 +35,15 @@ Currently, both the management and environment VPCs will be deployed in the same
 
 ### Management environment
 
+1. Specify a region ([options](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/using-regions-availability-zones.html#concepts-available-regions)).
+
+    ```sh
+    export AWS_DEFAULT_REGION=...
+    ```
+
 1. Set up the Terraform backend.
 
     ```sh
-    export AWS_DEFAULT_REGION=us-east-2
     cd terraform/bootstrap
     terraform init
     terraform apply

--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ Currently, both the management and environment VPCs will be deployed in the same
 1. Create the Terraform variables file.
 
     ```sh
-    cd terraform/env
+    cd ../env
     cp terraform.tfvars.example terraform.tfvars
     ```
 

--- a/README.md
+++ b/README.md
@@ -62,6 +62,8 @@ Currently, both the management and environment VPCs will be deployed in the same
     terraform apply -target=aws_eip.jenkins
     ```
 
+    _NOTE: There is a circular dependency between the Terraform and Packer configurations. This workaround only creates the subset of the environment required for the AMI build._
+
 1. Create the Jenkins secrets.
     1. Create a secrets file. _Note that, for simplicity, we're putting the secrets in a file not checked into version control. A real project should put the secrets in a [Vault](https://docs.ansible.com/ansible/latest/vault.html)._
 
@@ -107,8 +109,7 @@ Currently, both the management and environment VPCs will be deployed in the same
 1. Set up Terraform.
 
     ```sh
-    export AWS_DEFAULT_REGION=us-east-2
-    terraform init
+    terraform init "-backend-config=bucket=$(cd ../mgmt && terraform output env_backend_bucket)"
     ```
 
 1. Run the [deployment](#deployment) steps below.
@@ -128,7 +129,7 @@ For initial or subsequent deployment:
     terraform apply -target=aws_route53_record.db
     ```
 
-    _NOTE: There is a circular dependency between the Terraform and Packer configurations. This workaround only creates the subset of the environment required for the AMI build._
+    _NOTE: Ditto the [above](#management-environment) regarding circular dependency._
 
 1. Build the AMI.
 

--- a/README.md
+++ b/README.md
@@ -73,16 +73,7 @@ Currently, both the management and environment VPCs will be deployed in the same
 
     1. [Generate an SSH key.](https://github.com/GSA/jenkins-deploy#usage)
     1. Fill out the secrets file ([`ansible/group_vars/jenkins/secrets.yml`](../ansible/group_vars/jenkins/secrets.yml.example)).
-1. Deploy Jenkins.
-
-    ```sh
-    packer build \
-      -var jenkins_host=$(terraform output jenkins_host) \
-      ../../packer/jenkins.json
-
-    terraform apply
-    ```
-
+1. Run the [deployment](#mgmt-deployment) steps below.
 1. Create the Jenkins pipeline.
     1. Visit [Blue Ocean](https://jenkins.io/projects/blueocean/) interface.
 
@@ -95,6 +86,18 @@ Currently, both the management and environment VPCs will be deployed in the same
     1. For the GitHub organization, select `GSA`.
     1. Select `New Pipeline`.
     1. Select this repository.
+
+#### mgmt deployment
+
+Run the following to deploy Jenkins or any other changes to `mgmt`.
+
+```sh
+packer build \
+  -var jenkins_host=$(terraform output jenkins_host) \
+  ../../packer/jenkins.json
+
+terraform apply
+```
 
 ### Application environment
 
@@ -112,17 +115,6 @@ Currently, both the management and environment VPCs will be deployed in the same
     terraform init "-backend-config=bucket=$(cd ../mgmt && terraform output env_backend_bucket)"
     ```
 
-1. Run the [deployment](#deployment) steps below.
-1. Visit the setup page.
-
-    ```sh
-    open $(terraform output url)wp-admin/install.php
-    ```
-
-## Deployment
-
-For initial or subsequent deployment:
-
 1. Bootstrap the environment using Terraform.
 
     ```sh
@@ -130,6 +122,17 @@ For initial or subsequent deployment:
     ```
 
     _NOTE: Ditto the [above](#management-environment) regarding circular dependency._
+
+1. Run the [deployment](#env-deployment) steps below.
+1. Visit the setup page.
+
+    ```sh
+    open $(terraform output url)wp-admin/install.php
+    ```
+
+#### env deployment
+
+For initial or subsequent deployment:
 
 1. Build the AMI.
 
@@ -150,9 +153,9 @@ For initial or subsequent deployment:
 
 Note that if the public IP address changes after you set up the site initially, you will need to [change the site URL](https://codex.wordpress.org/Changing_The_Site_URL#Changing_the_Site_URL) in WordPress.
 
-## Troubleshooting
+#### Troubleshooting
 
-To SSH into the running instance:
+To SSH into the running WordPress instance:
 
 ```sh
 ssh $(terraform output ssh_user)@$(terraform output public_ip)

--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ Currently, both the management and environment VPCs will be deployed in the same
 1. Set up the Terraform backend.
 
     ```sh
+    export AWS_DEFAULT_REGION=us-east-2
     cd terraform/bootstrap
     terraform init
     terraform apply
@@ -48,7 +49,6 @@ Currently, both the management and environment VPCs will be deployed in the same
 
     ```sh
     cd ../mgmt
-    export AWS_DEFAULT_REGION=us-east-2
     terraform init
     ```
 
@@ -59,13 +59,13 @@ Currently, both the management and environment VPCs will be deployed in the same
     ```
 
 1. Create the Jenkins secrets.
-    1. [Generate an SSH key.](https://github.com/GSA/jenkins-deploy#usage)
-    1. Create a secrets file.
+    1. Create a secrets file. _Note that, for simplicity, we're putting the secrets in a file not checked into version control. A real project should put the secrets in a [Vault](https://docs.ansible.com/ansible/latest/vault.html)._
 
         ```sh
-        cp ../ansible/group_vars/jenkins/secrets.yml.example ../ansible/group_vars/jenkins/secrets.yml
+        cp ../../ansible/group_vars/jenkins/secrets.yml.example ../../ansible/group_vars/jenkins/secrets.yml
         ```
 
+    1. [Generate an SSH key.](https://github.com/GSA/jenkins-deploy#usage)
     1. Fill out the secrets file ([`ansible/group_vars/jenkins/secrets.yml`](../ansible/group_vars/jenkins/secrets.yml.example)).
 1. Deploy Jenkins.
 

--- a/README.md
+++ b/README.md
@@ -43,13 +43,12 @@ Currently, both the management and environment VPCs will be deployed in the same
     terraform init
     terraform apply
     ```
-    NOTE: You will need to replace your bucket name with something unique, because bucket names must be unique globally. If you get an error that the bucket name is not available, then your choice was not unique.
 
 1. Set up Terraform.
 
     ```sh
     cd ../mgmt
-    terraform init
+    terraform init "-backend-config=bucket=$(cd ../bootstrap && terraform output bucket)"
     ```
 
 1. Bootstrap the environment using Terraform.

--- a/README.md
+++ b/README.md
@@ -44,13 +44,18 @@ Currently, both the management and environment VPCs will be deployed in the same
     ```
     NOTE: You will need to replace your bucket name with something unique, because bucket names must be unique globally. If you get an error that the bucket name is not available, then your choice was not unique.
 
-1. Set up environment using Terraform.
+1. Set up Terraform.
 
     ```sh
     cd ../mgmt
     export AWS_DEFAULT_REGION=us-east-2
     terraform init
-    terraform apply
+    ```
+
+1. Bootstrap the environment using Terraform.
+
+    ```sh
+    terraform apply -target=aws_eip.jenkins
     ```
 
 1. Create the Jenkins secrets.
@@ -95,7 +100,7 @@ Currently, both the management and environment VPCs will be deployed in the same
     ```
 
 1. Fill out [`terraform.tfvars`](terraform/terraform.tfvars.example).
-1. Set up environment using Terraform.
+1. Set up Terraform.
 
     ```sh
     export AWS_DEFAULT_REGION=us-east-2

--- a/terraform/bootstrap/main.tf
+++ b/terraform/bootstrap/main.tf
@@ -3,7 +3,7 @@ provider "aws" {
 }
 
 resource "aws_s3_bucket" "backend" {
-  bucket = "${var.bucket}"
+  bucket_prefix = "${var.bucket_prefix}"
 
   versioning {
     enabled = true

--- a/terraform/bootstrap/outputs.tf
+++ b/terraform/bootstrap/outputs.tf
@@ -1,0 +1,3 @@
+output "bucket" {
+  value = "${aws_s3_bucket.backend.id}"
+}

--- a/terraform/bootstrap/variables.tf
+++ b/terraform/bootstrap/variables.tf
@@ -1,3 +1,3 @@
-variable "bucket" {
-  default = "devsecops-example-mgmt"
+variable "bucket_prefix" {
+  default = "devsecops-example-mgmt-"
 }

--- a/terraform/env/aws.tf
+++ b/terraform/env/aws.tf
@@ -5,8 +5,6 @@ provider "aws" {
 
 terraform {
   backend "s3" {
-    bucket = "devsecops-example-env"
-    # TODO better strategy for backend uniqueness
     key = "terraform/env.tfstate"
   }
 }

--- a/terraform/env/network.tf
+++ b/terraform/env/network.tf
@@ -16,9 +16,13 @@ module "network" {
   cidr = "${var.vpc_cidr}"
 }
 
+# ensure uniqueness within an account
+resource "random_pet" "flow_logs" {}
+
 module "flow_logs" {
   source = "github.com/GSA/terraform-vpc-flow-log"
   vpc_id = "${module.network.vpc_id}"
+  prefix = "env-${random_pet.flow_logs.id}-"
 }
 
 data "aws_subnet" "public" {

--- a/terraform/env/network.tf
+++ b/terraform/env/network.tf
@@ -2,8 +2,8 @@ module "network" {
   source = "terraform-aws-modules/vpc/aws"
 
   azs = [
-    "${data.aws_region.current.name}a",
-    "${data.aws_region.current.name}b"
+    "${data.aws_region.current.name}${var.azs[0]}",
+    "${data.aws_region.current.name}${var.azs[1]}"
   ]
 
   name = "devsecops-example"

--- a/terraform/env/network.tf
+++ b/terraform/env/network.tf
@@ -1,5 +1,7 @@
 module "network" {
   source = "terraform-aws-modules/vpc/aws"
+  # broken by https://github.com/terraform-aws-modules/terraform-aws-vpc/pull/36
+  version = ">= 1.0.0, < 1.8.0"
 
   azs = [
     "${data.aws_region.current.name}${var.azs[0]}",

--- a/terraform/env/vars.tf
+++ b/terraform/env/vars.tf
@@ -2,6 +2,11 @@ variable "vpc_cidr" {
   default = "10.0.0.0/16"
 }
 
+variable "azs" {
+  default = ["a", "b"]
+  description = "Availability zones to use within the specified region - pick two from https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/using-regions-availability-zones.html#using-regions-availability-zones-describe"
+}
+
 variable "public_subnet_cidr" {
   default = "10.0.0.0/24"
 }

--- a/terraform/mgmt/aws.tf
+++ b/terraform/mgmt/aws.tf
@@ -4,7 +4,6 @@ provider "aws" {
 
 terraform {
   backend "s3" {
-    bucket = "devsecops-example-mgmt"
     key = "terraform/mgmt.tfstate"
   }
 }

--- a/terraform/mgmt/iam.tf
+++ b/terraform/mgmt/iam.tf
@@ -1,5 +1,10 @@
+# avoid name conflicts - ensure multiple copies of the same role can exist in the same AWS account
+resource "random_id" "jenkins_iam_role_suffix" {
+  byte_length = 8
+}
+
 module "jenkins_master_role" {
   source = "github.com/18F/cg-provision/terraform/modules/iam_role"
   iam_policy = "${file("${path.module}/files/role_policy.json")}"
-  role_name = "${var.jenkins_iam_role_name}"
+  role_name = "${var.jenkins_iam_role_prefix}${random_id.jenkins_iam_role_suffix.hex}"
 }

--- a/terraform/mgmt/jenkins.tf
+++ b/terraform/mgmt/jenkins.tf
@@ -37,8 +37,13 @@ module "jenkins_instances" {
 }
 
 resource "aws_eip" "jenkins" {
-  instance = "${module.jenkins_instances.instance_id}"
   vpc = true
+}
+
+# the association needs to be done outside of the aws_eip resource so that the EIP can be created independent of the corresponding instance
+resource "aws_eip_association" "jenkins" {
+  instance_id   = "${module.jenkins_instances.instance_id}"
+  allocation_id = "${aws_eip.jenkins.id}"
 }
 
 # https://tech.gogoair.com/immutable-jenkins-ae54e4a37a6a

--- a/terraform/mgmt/network.tf
+++ b/terraform/mgmt/network.tf
@@ -10,11 +10,13 @@ module "network" {
   public_subnets = ["${var.public_subnet_cidr}"]
 }
 
+# ensure uniqueness within an account
+resource "random_pet" "flow_logs" {}
+
 module "flow_logs" {
   source = "github.com/GSA/terraform-vpc-flow-log"
   vpc_id = "${module.network.vpc_id}"
-  # temporary, while working in a single account
-  prefix = "mgmt"
+  prefix = "mgmt-${random_pet.flow_logs.id}-"
 }
 
 data "aws_subnet" "public" {

--- a/terraform/mgmt/network.tf
+++ b/terraform/mgmt/network.tf
@@ -1,8 +1,7 @@
 module "network" {
   source = "terraform-aws-modules/vpc/aws"
 
-  # somewhat arbitrary - the later in the alphabet, the newer, which seems to provision faster
-  azs = ["${data.aws_region.current.name}c"]
+  azs = ["${data.aws_region.current.name}a"]
   cidr = "${var.vpc_cidr}"
   enable_dns_hostnames = true
   enable_dns_support = true

--- a/terraform/mgmt/network.tf
+++ b/terraform/mgmt/network.tf
@@ -1,7 +1,7 @@
 module "network" {
   source = "terraform-aws-modules/vpc/aws"
 
-  azs = ["${data.aws_region.current.name}a"]
+  azs = ["${data.aws_region.current.name}${var.az}"]
   cidr = "${var.vpc_cidr}"
   enable_dns_hostnames = true
   enable_dns_support = true

--- a/terraform/mgmt/network.tf
+++ b/terraform/mgmt/network.tf
@@ -1,5 +1,6 @@
 module "network" {
   source = "terraform-aws-modules/vpc/aws"
+  version = "~> 1.0"
 
   azs = ["${data.aws_region.current.name}${var.az}"]
   cidr = "${var.vpc_cidr}"

--- a/terraform/mgmt/outputs.tf
+++ b/terraform/mgmt/outputs.tf
@@ -1,3 +1,7 @@
 output "jenkins_host" {
   value = "${aws_eip.jenkins.public_ip}"
 }
+
+output "env_backend_bucket" {
+  value = "${aws_s3_bucket.env_backend.id}"
+}

--- a/terraform/mgmt/s3.tf
+++ b/terraform/mgmt/s3.tf
@@ -1,7 +1,7 @@
 // need a different backend bucket from the mgmt one due to
 // https://github.com/hashicorp/terraform/issues/15648
 resource "aws_s3_bucket" "env_backend" {
-  bucket = "${var.env_backend_bucket}"
+  bucket_prefix = "${var.env_backend_bucket_prefix}"
 
   versioning {
     enabled = true

--- a/terraform/mgmt/variables.tf
+++ b/terraform/mgmt/variables.tf
@@ -2,6 +2,11 @@ variable "vpc_cidr" {
   default = "10.0.0.0/16"
 }
 
+variable "az" {
+  default = "a"
+  description = "Availability zone to use within the specified region - pick from https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/using-regions-availability-zones.html#using-regions-availability-zones-describe"
+}
+
 variable "public_subnet_cidr" {
   default = "10.0.0.0/24"
 }

--- a/terraform/mgmt/variables.tf
+++ b/terraform/mgmt/variables.tf
@@ -10,8 +10,8 @@ variable "jenkins_instance_type" {
   default = "t2.micro"
 }
 
-variable "jenkins_iam_role_name" {
-  default = "jenkins_role"
+variable "jenkins_iam_role_prefix" {
+  default = "jenkins_role_"
 }
 
 variable "env_backend_bucket_prefix" {

--- a/terraform/mgmt/variables.tf
+++ b/terraform/mgmt/variables.tf
@@ -14,6 +14,6 @@ variable "jenkins_iam_role_name" {
   default = "jenkins_role"
 }
 
-variable "env_backend_bucket" {
+variable "env_backend_bucket_prefix" {
   default = "devsecops-example-env"
 }


### PR DESCRIPTION
https://trello.com/c/LDokLRyy/217-devsecops-example-remove-cyclical-dependency-between-infrastructure-and-ami-setup

At the moment, the `mgmt` environment needs the Jenkins AMI to be available to fully build the infrastructure. The AMI, however, can't be built without parts of the infrastructure being present. This sets up a minimal subset of the infrastructure as a first step to allow the AMI build to happen, then adds the rest of the infrastructure later.

Note: *I have not tested this.** @Vermyndax Mind confirming whether it works for you or not?