### PR TITLE
add other common dependencies to the build container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,4 +5,4 @@ FROM williamyeh/ansible:alpine3
 COPY --from=packer /bin/packer /bin/packer
 COPY --from=terraform /bin/terraform /bin/terraform
 
-RUN apk add --no-cache make
+RUN apk add --no-cache git make

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,3 +6,6 @@ COPY --from=packer /bin/packer /bin/packer
 COPY --from=terraform /bin/terraform /bin/terraform
 
 RUN apk add --no-cache git make
+
+RUN pip install awscli --upgrade --user
+ENV PATH="/root/.local/bin:${PATH}"

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,3 +4,5 @@ FROM hashicorp/terraform:light as terraform
 FROM williamyeh/ansible:alpine3
 COPY --from=packer /bin/packer /bin/packer
 COPY --from=terraform /bin/terraform /bin/terraform
+
+RUN apk add --no-cache make


### PR DESCRIPTION
Useful for getting complex build commands out of the CircleCI config.