### PR TITLE
explain manual steps for setting up the environment

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -50,17 +50,12 @@ jobs:
           paths:
             - ./*
 
-  deploy_env:
+  build_ami:
     docker:
       - image: 18fgsa/devsecops-builder:alpine
     steps:
       - attach_workspace:
           at: .
-
-      - add_ssh_keys
-      - run:
-          name: Disable host key checking
-          command: printf "\nHost *\n\tStrictHostKeyChecking no" >> ~/.ssh/config
 
       - run:
           name: Bootstrap the environment
@@ -83,6 +78,19 @@ jobs:
               ../../packer/wordpress.json
           working_directory: ~/project/terraform/env
 
+  # AMI builds are slow, so keeping the environment deploy separate so it can be re-run separately if needed
+  deploy_env:
+    docker:
+      - image: 18fgsa/devsecops-builder:alpine
+    steps:
+      - attach_workspace:
+          at: .
+
+      - add_ssh_keys
+      - run:
+          name: Disable host key checking
+          command: printf "\nHost *\n\tStrictHostKeyChecking no" >> ~/.ssh/config
+
       - run:
           name: Deploy the full environment
           command: terraform apply -input=false -auto-approve
@@ -95,10 +103,16 @@ workflows:
     jobs:
       - validate_packer
       - validate_terraform
-      - deploy_env:
+      - build_ami:
           filters:
             branches:
               only: master
           requires:
             - validate_packer
             - validate_terraform
+      - deploy_env:
+          filters:
+            branches:
+              only: master
+          requires:
+            - build_ami

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,6 +11,10 @@ jobs:
       #     name: Download Ansible dependencies
       #     command: ansible-galaxy install -p roles -r requirements.yml
       #     working_directory: ~/project/ansible
+      - run:
+          name: Validate Ansible playbook
+          command: ansible-playbook --syntax-check -i "localhost," -c local wordpress.yml
+          working_directory: ~/project/ansible
 
       - run:
           name: Validate WordPress template

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -48,14 +48,7 @@ jobs:
 
       - run:
           name: Build WordPress AMI
-          command: |
-            packer build \
-              -var db_host=$(terraform output db_host) \
-              -var db_name=$(terraform output db_name) \
-              -var db_user=$(terraform output db_user) \
-              -var "db_pass=${TF_VAR_db_pass}" \
-              ../../packer/wordpress.json
-          working_directory: ~/project/terraform/env
+          command: make ami
 
   # AMI builds are slow, so keeping the environment deploy separate so it can be re-run separately if needed
   deploy_env:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,19 +1,20 @@
 version: 2
 jobs:
-  validate_packer:
+  install_and_validate:
     docker:
-      - image: hashicorp/packer:light
+      - image: 18fgsa/devsecops-builder:alpine
     steps:
       - checkout
+
+      # this command fails if the requirements.yml is empty
+      # - run:
+      #     name: Download Ansible dependencies
+      #     command: ansible-galaxy install -p roles -r requirements.yml
+      #     working_directory: ~/project/ansible
+
       - run:
           name: Validate WordPress template
           command: packer validate -syntax-only packer/wordpress.json
-
-  validate_terraform:
-    docker:
-      - image: hashicorp/terraform:light
-    steps:
-      - checkout
 
       - run:
           name: bootstrap - Set up Terraform
@@ -45,6 +46,7 @@ jobs:
           name: env - Validate Terraform
           command: terraform validate
           working_directory: ~/project/terraform/env
+
       - persist_to_workspace:
           root: .
           paths:
@@ -61,11 +63,6 @@ jobs:
           name: Bootstrap the environment
           command: terraform apply -input=false -auto-approve -target=aws_route53_record.db
           working_directory: ~/project/terraform/env
-
-      # this command fails if the requirements.yml is empty
-      # - run:
-      #     name: Download Ansible dependencies
-      #     command: ansible-galaxy install -p ansible/roles -r ansible/requirements.yml
 
       - run:
           name: Build WordPress AMI
@@ -101,15 +98,13 @@ workflows:
 
   validate_and_deploy:
     jobs:
-      - validate_packer
-      - validate_terraform
+      - install_and_validate
       - build_ami:
           filters:
             branches:
               only: master
           requires:
-            - validate_packer
-            - validate_terraform
+            - install_and_validate
       - deploy_env:
           filters:
             branches:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,27 +6,9 @@ jobs:
     steps:
       - checkout
 
-      # this command fails if the requirements.yml is empty
-      # - run:
-      #     name: Download Ansible dependencies
-      #     command: ansible-galaxy install -p roles -r requirements.yml
-      #     working_directory: ~/project/ansible
-      - run:
-          name: Validate Ansible playbook
-          command: ansible-playbook --syntax-check -i "localhost," -c local wordpress.yml
-          working_directory: ~/project/ansible
-
-      - run:
-          name: Validate WordPress template
-          command: packer validate -syntax-only packer/wordpress.json
-
       - run:
           name: bootstrap - Set up Terraform
           command: terraform init -backend=false -input=false
-          working_directory: ~/project/terraform/bootstrap
-      - run:
-          name: bootstrap - Validate Terraform
-          command: terraform validate
           working_directory: ~/project/terraform/bootstrap
 
       - run:
@@ -37,19 +19,15 @@ jobs:
           name: mgmt - Set up Terraform
           command: terraform init -backend=false -input=false
           working_directory: ~/project/terraform/mgmt
-      - run:
-          name: mgmt - Validate Terraform
-          command: terraform validate
-          working_directory: ~/project/terraform/mgmt
 
       - run:
           name: env - Set up Terraform
           command: terraform init "-backend-config=bucket=$TF_ENV_BUCKET" -input=false
           working_directory: ~/project/terraform/env
+
       - run:
-          name: env - Validate Terraform
-          command: terraform validate
-          working_directory: ~/project/terraform/env
+          name: Run validations
+          command: make validate
 
       - persist_to_workspace:
           root: .

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,10 @@
+validate: roles
+	cd ansible && ansible-playbook --syntax-check -i "localhost," -c local wordpress.yml
+	packer validate -syntax-only packer/wordpress.json
+	cd terraform/bootstrap && terraform validate
+	cd terraform/mgmt && terraform validate
+	cd terraform/env && terraform validate
+
+roles:
+	# this command fails if the requirements.yml is empty
+	# cd ansible && ansible-galaxy install -p roles -r requirements.yml

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,16 @@
+DB_HOST = $(shell cd terraform/env && terraform output db_host)
+DB_NAME = $(shell cd terraform/env && terraform output db_name)
+DB_USER = $(shell cd terraform/env && terraform output db_user)
+
+ami: roles
+	cd terraform/env && \
+		packer build \
+			-var db_host=$(DB_HOST) \
+			-var db_name=$(DB_NAME) \
+			-var db_user=$(DB_USER) \
+			-var "db_pass=${TF_VAR_db_pass}" \
+			../../packer/wordpress.json
+
 validate: roles
 	cd ansible && ansible-playbook --syntax-check -i "localhost," -c local wordpress.yml
 	packer validate -syntax-only packer/wordpress.json

--- a/README.md
+++ b/README.md
@@ -32,8 +32,9 @@ Currently, both the management and environment VPCs will be deployed in the same
 1. Install Ansible dependencies.
 
     ```sh
-    ansible-galaxy install -p ansible/roles -r ansible/requirements.yml
+    make roles
     ```
+
 1. Specify a region ([options](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/using-regions-availability-zones.html#concepts-available-regions)).
 
     ```sh


### PR DESCRIPTION
Builds on #74. Diff: https://github.com/GSA/devsecops-example/compare/split-deploy...manual-setup

There's still duplication between the CircleCI config and these instructions, but at least the meaty commands are now in Make targets where they can be used by both.