### PR TITLE
configure the environment as a spoke VPC

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ This is just an example implementation of the GSA DevSecOps principles/component
 
 A `mgmt` ("management") VPC is created.
 
-WordPress runs on a hardened Ubuntu 16.04 EC2 instance in a public subnet, and connects to a MySQL RDS instance in a private subnet. All of this is isolated in an `env` ("environment") VPC.
+WordPress runs on a hardened Ubuntu 16.04 EC2 instance in a public subnet, and connects to a MySQL RDS instance in a private subnet. All of this is isolated in an `env` ("environment") VPC, which is set up with [a VPN to a central Transit VPC](https://github.com/GSA/grace-core/tree/master/terraform/spoke).
 
 Currently, both the management and environment VPCs will be deployed in the same account, but we are moving to having them separate.
 

--- a/terraform/env/network.tf
+++ b/terraform/env/network.tf
@@ -18,18 +18,21 @@ module "network" {
   enable_nat_gateway   = true
   cidr                 = "${var.vpc_cidr}"
 
-  # just for demonstration purposes - not otherwise used
-  private_subnets = ["${cidrsubnet(var.vpc_cidr, 8, 1)}"]
-
   # per https://docs.aws.amazon.com/solutions/latest/cisco-based-transit-vpc/step3.html
+  enable_vpn_gateway                 = true
   propagate_private_route_tables_vgw = true
+
+  tags = {
+    # only actually need it on the VPN gateway, but this is the only way to do it as of module 1.32.0
+    # https://docs.aws.amazon.com/solutions/latest/cisco-based-transit-vpc/step3.html
+    "transitvpc:spoke" = "true"
+  }
 }
 
 module "spoke" {
   source = "github.com/GSA/grace-core//terraform/spoke"
 
-  num_gateway_subnets = "1"
-  gateway_subnet_ids  = "${module.network.private_subnets}"
+  vpc_id = "${module.network.vpc_id}"
 }
 
 # ensure uniqueness within an account

--- a/terraform/env/network.tf
+++ b/terraform/env/network.tf
@@ -29,11 +29,12 @@ module "network" {
   }
 }
 
-module "spoke" {
-  source = "github.com/GSA/grace-core//terraform/spoke"
-
-  vpc_id = "${module.network.vpc_id}"
-}
+# leaving commented out, because we don't want to actually open up a VPN connection to on-prem
+# module "spoke" {
+#   source = "github.com/GSA/grace-core//terraform/spoke"
+#
+#   vpc_id = "${module.network.vpc_id}"
+# }
 
 # ensure uniqueness within an account
 resource "random_pet" "flow_logs" {}

--- a/terraform/env/network.tf
+++ b/terraform/env/network.tf
@@ -17,6 +17,19 @@ module "network" {
   public_subnets       = ["${cidrsubnet(var.vpc_cidr, 8, 0)}"]
   enable_nat_gateway   = true
   cidr                 = "${var.vpc_cidr}"
+
+  # just for demonstration purposes - not otherwise used
+  private_subnets = ["${cidrsubnet(var.vpc_cidr, 8, 1)}"]
+
+  # per https://docs.aws.amazon.com/solutions/latest/cisco-based-transit-vpc/step3.html
+  propagate_private_route_tables_vgw = true
+}
+
+module "spoke" {
+  source = "github.com/GSA/grace-core//terraform/spoke"
+
+  num_gateway_subnets = "1"
+  gateway_subnet_ids  = "${module.network.private_subnets}"
 }
 
 # ensure uniqueness within an account


### PR DESCRIPTION
Builds on #78.

This is an example of setting up a spoke VPC using the `spoke` module from grace-core. Getting this error:

```
* module.spoke.aws_route_table_association.route_asso: 1 error(s) occurred:

* aws_route_table_association.route_asso: Resource.AlreadyAssociated: the specified association for route table rtb-XXXXXXXX conflicts with an existing association
```

Could use some help understanding what to do to fix that.